### PR TITLE
fix: improve charts [INFRA-3109]

### DIFF
--- a/charts/accountapp/templates/ingress.yaml
+++ b/charts/accountapp/templates/ingress.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "accountapp.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -36,7 +37,7 @@ spec:
               service:
                 name: {{ $fullName }}
                 port:
-                  number: {{ int ($.Values.service.port) }}
+                  number: {{ $svcPort }}
         {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/accountapp/templates/ingress.yaml
+++ b/charts/accountapp/templates/ingress.yaml
@@ -11,8 +11,8 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-{{- if .Values.ingress.ingressClassName }}
-  ingressClassName: {{ .Values.ingress.ingressClassName }}
+{{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
 {{- end }}
 {{- if .Values.ingress.tls }}
   tls:

--- a/charts/accountapp/values.yaml
+++ b/charts/accountapp/values.yaml
@@ -20,6 +20,7 @@ service:
 # Please define ingress settings into environment variable
 ingress:
   enabled: true
+  className: ""
 #  annotations:
 #    "cert-manager.io/cluster-issuer": "letsencrypt-prod"
 #    "nginx.ingress.kubernetes.io/proxy-body-size": "500m"

--- a/charts/custom-distribution-service/templates/ingress.yaml
+++ b/charts/custom-distribution-service/templates/ingress.yaml
@@ -12,8 +12,8 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-{{- if .Values.ingress.ingressClassName }}
-  ingressClassName: {{ .Values.ingress.ingressClassName }}
+{{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
 {{- end }}
 {{- if .Values.ingress.tls }}
   tls:

--- a/charts/custom-distribution-service/templates/ingress.yaml
+++ b/charts/custom-distribution-service/templates/ingress.yaml
@@ -37,7 +37,7 @@ spec:
               service:
                 name: {{ $fullName }}
                 port:
-                  number: {{ int ($.Values.service.port) }}
+                  number: {{ $svcPort }}
         {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/custom-distribution-service/values.yaml
+++ b/charts/custom-distribution-service/values.yaml
@@ -32,6 +32,7 @@ service:
   port: 8080
 ingress:
   enabled: false
+  className: ""
   annotations: {}
   # kubernetes.io/tls-acme: "true"
   hosts:

--- a/charts/incrementals-publisher/templates/ingress.yaml
+++ b/charts/incrementals-publisher/templates/ingress.yaml
@@ -12,8 +12,8 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-{{- if .Values.ingress.ingressClassName }}
-  ingressClassName: {{ .Values.ingress.ingressClassName }}
+{{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
 {{- end }}
 {{- if .Values.ingress.tls }}
   tls:

--- a/charts/incrementals-publisher/templates/ingress.yaml
+++ b/charts/incrementals-publisher/templates/ingress.yaml
@@ -37,7 +37,7 @@ spec:
               service:
                 name: {{ $fullName }}
                 port:
-                  number: {{ int ($.Values.service.port) }}
+                  number: {{ $svcPort }}
         {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/incrementals-publisher/values.yaml
+++ b/charts/incrementals-publisher/values.yaml
@@ -32,6 +32,7 @@ service:
   port: 8080
 ingress:
   enabled: false
+  className: ""
   annotations: {}
   # kubernetes.io/tls-acme: "true"
   hosts:

--- a/charts/javadoc/templates/ingress.yaml
+++ b/charts/javadoc/templates/ingress.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "javadoc.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -36,7 +37,7 @@ spec:
               service:
                 name: {{ $fullName }}
                 port:
-                  number: {{ int ($.Values.service.port) }}
+                  number: {{ $svcPort }}
         {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/javadoc/templates/ingress.yaml
+++ b/charts/javadoc/templates/ingress.yaml
@@ -11,8 +11,8 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-{{- if .Values.ingress.ingressClassName }}
-  ingressClassName: {{ .Values.ingress.ingressClassName }}
+{{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
 {{- end }}
 {{- if .Values.ingress.tls }}
   tls:

--- a/charts/javadoc/values.yaml
+++ b/charts/javadoc/values.yaml
@@ -15,6 +15,7 @@ fullnameOverride: ""
 
 ingress:
   enabled: false
+  className: ""
 #  annotations:
 #    "cert-manager.io/cluster-issuer": "letsencrypt-prod"
 #    "nginx.ingress.kubernetes.io/proxy-body-size": "500m"

--- a/charts/jenkins-wiki-exporter/templates/ingress.yaml
+++ b/charts/jenkins-wiki-exporter/templates/ingress.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "jenkins-wiki-exporter.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -36,7 +37,7 @@ spec:
               service:
                 name: {{ $fullName }}
                 port:
-                  number: {{ int ($.Values.service.port) }}
+                  number: {{ $svcPort }}
         {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/jenkins-wiki-exporter/templates/ingress.yaml
+++ b/charts/jenkins-wiki-exporter/templates/ingress.yaml
@@ -11,8 +11,8 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-{{- if .Values.ingress.ingressClassName }}
-  ingressClassName: {{ .Values.ingress.ingressClassName }}
+{{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
 {{- end }}
 {{- if .Values.ingress.tls }}
   tls:

--- a/charts/jenkins-wiki-exporter/values.yaml
+++ b/charts/jenkins-wiki-exporter/values.yaml
@@ -15,6 +15,7 @@ service:
   port: 80
 ingress:
   enabled: false
+  className: ""
 # Please define ingress settings into environment variable
 #  enabled: true
 #  annotations:

--- a/charts/jenkinsio/templates/ingress.yaml
+++ b/charts/jenkinsio/templates/ingress.yaml
@@ -11,8 +11,8 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-{{- if .Values.ingress.ingressClassName }}
-  ingressClassName: {{ .Values.ingress.ingressClassName }}
+{{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
 {{- end }}
 {{- if .Values.ingress.tls }}
   tls:

--- a/charts/jenkinsio/templates/ingress.yaml
+++ b/charts/jenkinsio/templates/ingress.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "jenkinsio.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -36,7 +37,7 @@ spec:
               service:
                 name: {{ .serviceName }}
                 port:
-                  number: {{ int ($.Values.service.port) }}
+                  number: {{ $svcPort }}
         {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/jenkinsio/values.yaml
+++ b/charts/jenkinsio/values.yaml
@@ -19,8 +19,9 @@ service:
   type: ClusterIP
   port: 80
 # Please define ingress settings into environment variable
-# ingress:
-#  enabled: true
+ingress:
+  enabled: false
+  className: ""
 #  annotations:
 #    "cert-manager.io/cluster-issuer": "letsencrypt-prod"
 #    "nginx.ingress.kubernetes.io/proxy-body-size": "500m"

--- a/charts/keycloak/templates/ingress.yaml
+++ b/charts/keycloak/templates/ingress.yaml
@@ -13,8 +13,8 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-{{- if .Values.ingress.ingressClassName }}
-  ingressClassName: {{ .Values.ingress.ingressClassName }}
+{{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
 {{- end }}
   {{- if .Values.ingress.tls }}
   tls:

--- a/charts/keycloak/templates/ingress.yaml
+++ b/charts/keycloak/templates/ingress.yaml
@@ -37,13 +37,13 @@ spec:
               service:
                 name: keycloak-http
                 port:
-                  number: 80
+                  number: {{ $svcPort }}
           - path: /auth/admin/
             pathType: Prefix
             backend:
               service:
                 name: {{ $fullName }}-404
                 port:
-                  number: 80
+                  number: {{ $svcPort }}
     {{- end }}
   {{- end }}

--- a/charts/keycloak/values.yaml
+++ b/charts/keycloak/values.yaml
@@ -8,6 +8,7 @@ service:
 
 ingress:
   enabled: false
+  className: ""
   annotations: {}
     # kubernetes.io/tls-acme: "true"
   hosts:

--- a/charts/mirrorbits/templates/ingress.yaml
+++ b/charts/mirrorbits/templates/ingress.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "mirrorbits.fullname" . -}}
-{{- $svcPort := .Values.service.port -}}
+{{- $svcPort := .Values.service.mirrorbits.port -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -38,7 +38,7 @@ spec:
               service:
                 name: {{ if .serviceNameSuffix }}{{ $fullName }}-{{ .serviceNameSuffix }}{{ else }}{{ $fullName }}{{ end }}
                 port:
-                  number: 80
+                  number: {{ $svcPort }}
         {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/mirrorbits/templates/ingress.yaml
+++ b/charts/mirrorbits/templates/ingress.yaml
@@ -13,8 +13,8 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-{{- if .Values.ingress.ingressClassName }}
-  ingressClassName: {{ .Values.ingress.ingressClassName }}
+{{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
 {{- end }}
 {{- if .Values.ingress.tls }}
   tls:

--- a/charts/mirrorbits/values.yaml
+++ b/charts/mirrorbits/values.yaml
@@ -47,7 +47,8 @@ service:
     port: 80
 
 ingress:
-  enabled: true
+  enabled: false
+  className: ""
   annotations: {}
     # kubernetes.io/tls-acme: "true"
   hosts:

--- a/charts/plugin-site/templates/ingress.yaml
+++ b/charts/plugin-site/templates/ingress.yaml
@@ -12,8 +12,8 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-{{- if .Values.ingress.ingressClassName }}
-  ingressClassName: {{ .Values.ingress.ingressClassName }}
+{{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
 {{- end }}
 {{- if .Values.ingress.tls }}
   tls:

--- a/charts/plugin-site/values.yaml
+++ b/charts/plugin-site/values.yaml
@@ -43,6 +43,7 @@ service:
 # Please define ingress settings into environment variable
 ingress:
   enabled: false
+  className: ""
   paths:
     - path: /api/(.*)
       svcName: backend

--- a/charts/reports/templates/ingress.yaml
+++ b/charts/reports/templates/ingress.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "reports.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -36,7 +37,7 @@ spec:
               service:
                 name: {{ $fullName }}
                 port:
-                  number: {{ int ($.Values.service.port) }}
+                  number: {{ $svcPort }}
         {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/reports/templates/ingress.yaml
+++ b/charts/reports/templates/ingress.yaml
@@ -11,8 +11,8 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-{{- if .Values.ingress.ingressClassName }}
-  ingressClassName: {{ .Values.ingress.ingressClassName }}
+{{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
 {{- end }}
 {{- if .Values.ingress.tls }}
   tls:

--- a/charts/reports/values.yaml
+++ b/charts/reports/values.yaml
@@ -15,6 +15,7 @@ fullnameOverride: ""
 
 ingress:
   enabled: false
+  className: ""
 #  annotations:
 #    "cert-manager.io/cluster-issuer": "letsencrypt-prod"
 #    "nginx.ingress.kubernetes.io/proxy-body-size": "500m"

--- a/charts/uplink/templates/ingress.yaml
+++ b/charts/uplink/templates/ingress.yaml
@@ -12,8 +12,8 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-{{- if .Values.ingress.ingressClassName }}
-  ingressClassName: {{ .Values.ingress.ingressClassName }}
+{{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
 {{- end }}
 {{- if .Values.ingress.tls }}
   tls:

--- a/charts/uplink/templates/ingress.yaml
+++ b/charts/uplink/templates/ingress.yaml
@@ -37,7 +37,7 @@ spec:
               service:
                 name: {{ $fullName }}
                 port:
-                  number: {{ int ($.Values.service.port) }}
+                  number: {{ $svcPort }}
         {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/uplink/values.yaml
+++ b/charts/uplink/values.yaml
@@ -37,6 +37,7 @@ service:
 
 ingress:
   enabled: false
+  className: ""
   annotations:
     kubernetes.io/tls-acme: "true"
     nginx.ingress.kubernetes.io/rewrite-target: /


### PR DESCRIPTION
- replace "ingressClassName" field in values.yaml by "className" (no need for "ingress" prefix), and set its default empty value
- set $svcPort value at the beginnning of the ingress templates so we won't need to cast it to `int` in the range ports of ingressses

Ref: https://issues.jenkins.io/projects/INFRA/issues/INFRA-3109