### PR TITLE
fix(mirrorbits): put mirrorbits service values on root service

### DIFF
--- a/charts/mirrorbits/Chart.yaml
+++ b/charts/mirrorbits/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "v0.5.1"
 description: Mirrobits helm chart for Kubernetes
 name: mirrorbits
-version: 0.1.1
+version: 0.2.0
 maintainers:
   - name: olblak
     email: me@olblak.com

--- a/charts/mirrorbits/templates/ingress.yaml
+++ b/charts/mirrorbits/templates/ingress.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "mirrorbits.fullname" . -}}
-{{- $svcPort := .Values.service.mirrorbits.port -}}
+{{- $svcPort := .Values.service.port -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:

--- a/charts/mirrorbits/templates/service.yaml
+++ b/charts/mirrorbits/templates/service.yaml
@@ -5,9 +5,9 @@ metadata:
   labels:
 {{ include "mirrorbits.labels" . | indent 4 }}
 spec:
-  type: {{ .Values.service.mirrorbits.type }}
+  type: {{ .Values.service.type }}
   ports:
-    - port: {{ .Values.service.mirrorbits.port }}
+    - port: {{ .Values.service.port }}
       targetPort: 8080
       protocol: TCP
       name: http

--- a/charts/mirrorbits/values.yaml
+++ b/charts/mirrorbits/values.yaml
@@ -39,10 +39,9 @@ securityContext: {}
   # runAsUser: 1000
 
 service:
+  type: ClusterIP
+  port: 80
   files:
-    type: ClusterIP
-    port: 80
-  mirrorbits:
     type: ClusterIP
     port: 80
 


### PR DESCRIPTION
fix 'templates/: template: mirrorbits/templates/NOTES.txt:8:39: executing mirrorbits/templates/NOTES.txt at <.Values.service.type>: wrong type for value; expected string; got interface {}'

Ref: https://github.com/jenkins-infra/charts/pull/1642#pullrequestreview-799185857