### PR TITLE
fix(jenkinsio): nginx config moved from helmfile configuration

### DIFF
--- a/charts/jenkinsio/Chart.yaml
+++ b/charts/jenkinsio/Chart.yaml
@@ -1,7 +1,6 @@
 apiVersion: v1
-appVersion: "1.0"
 description: A Helm chart for jenkins.io
 maintainers:
 - name: timja
 name: jenkinsio
-version: 0.0.23
+version: 0.1.0

--- a/charts/jenkinsio/templates/nginx-configmap.yaml
+++ b/charts/jenkinsio/templates/nginx-configmap.yaml
@@ -19,7 +19,14 @@ data:
         return 301 https://www.jenkins.io$request_uri;
       }
       {{- end }}
-  
+
+      if ( $scheme = "http" ) {
+        rewrite ^/((?!patron|maven-site|jenkins.jnlp).+)$ https://www.jenkins.io/$1 permanent;
+        rewrite ^/$ https://$host permanent;
+      }
+      more_set_headers X-Content-Type-Options "nosniff";
+      more_set_headers X-Frame-Options "DENY";
+
       root   /usr/share/nginx/html;
 
       location / {
@@ -30,8 +37,6 @@ data:
             rewrite ^/$ https://www.jenkins.io/$lang$1;
           }   
       }
-      
-      add_header X-Frame-Options "DENY";
 
       location ~* \.(?:css|js|woff|eot|svg|ttf|otf|png|gif|jpe?g) {
         expires 2d;


### PR DESCRIPTION
Was here before: https://github.com/jenkins-infra/charts/blob/main/config/jenkinsio.yaml\#L7-L13
Moved in the chart in order to get rid of nginx.ingress.kubernetes.io/configuration-snippet triggering error related to https://github.com/kubernetes/ingress-nginx/issues/7837