### PR TITLE
No longer rewrite /foo to /foo/

### DIFF
--- a/charts/plugin-site/Chart.yaml
+++ b/charts/plugin-site/Chart.yaml
@@ -5,4 +5,4 @@ name: plugin-site
 maintainers:
   - name: timja
   - name: halkeye
-version: 0.0.3
+version: 0.0.4

--- a/charts/plugin-site/templates/nginx-configmap.yaml
+++ b/charts/plugin-site/templates/nginx-configmap.yaml
@@ -25,7 +25,5 @@ data:
         expires +1y;
       }
 
-      rewrite ^([^.]*[^/])$ $1/ permanent;
-
       try_files $uri $uri/index.html =404;
     }


### PR DESCRIPTION
Nginx will load both files successfully, and canonical meta tag will
merge any seo type things.

This allows for /:pluginname/issues to work